### PR TITLE
OCA#13: Temporarily disable admin GraphQL API

### DIFF
--- a/server/src/config/production.json
+++ b/server/src/config/production.json
@@ -4,7 +4,7 @@
   "cors": true,
   "log": "verbose",
   "auth": {
-    "enabled": false,
+    "enabled": true,
     "jwtAlgorithm": "HS256",
     "jwtExpire": "1h"
   },

--- a/server/src/graphql.js
+++ b/server/src/graphql.js
@@ -12,6 +12,7 @@ import { TemplateMutation, TemplateQuery } from './layout/graphql/template';
 import { ViewMutation, ViewQuery } from './layout/graphql/view';
 import { RouteMutation, RouteQuery } from './layout/graphql/route';
 import { ProjectMutation, ProjectQuery } from './projects/graphql/project';
+import { conditionalMW } from './utils/express-utils';
 
 const GuestQueryType = new GraphQLObjectType({
   name: 'Query',
@@ -54,7 +55,7 @@ const AdminMutationType = new GraphQLObjectType({
 });
 
 const router = new Router();
-const { graphiql } = getConfig();
+const { graphiql, auth } = getConfig();
 
 const querySchema = new GraphQLSchema({
   query: GuestQueryType,
@@ -66,10 +67,12 @@ export const adminSchema = new GraphQLSchema({
 });
 
 router.use('/admin',
-  graphqlHTTP({
-    graphiql,
-    schema: adminSchema,
-  }));
+  /* TODO: fix this in #12 with proper authentication */
+  conditionalMW(!auth.enabled,
+    graphqlHTTP({
+      graphiql,
+      schema: adminSchema,
+    })));
 
 router.use('/',
   graphqlHTTP({

--- a/server/src/utils/express-utils.js
+++ b/server/src/utils/express-utils.js
@@ -1,0 +1,10 @@
+export function emptyMW() {
+  return (request, response, next) => next();
+}
+
+export function conditionalMW(condition, middleware) {
+  if (!condition || middleware === undefined) {
+    return emptyMW();
+  }
+  return middleware;
+}


### PR DESCRIPTION
Disable admin gql API endpoint for the MVP.
It will be turned back on once #12 is implemented.

Closes #13 