### PR TITLE
OCA#18: Fix e-mail button appearance on Safari

### DIFF
--- a/client/src/custom/components/PureButton/index.css
+++ b/client/src/custom/components/PureButton/index.css
@@ -12,8 +12,10 @@
     box-sizing: border-box;
     border-radius: 1.3rem;
 
-    display: inline-block;
     cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
 }
 
 .button-link:hover {


### PR DESCRIPTION
Set the appearance webkit classes accordingly.

Closes #18 